### PR TITLE
Pass path to config file via cli flag

### DIFF
--- a/cfg/cfg.go
+++ b/cfg/cfg.go
@@ -8,6 +8,7 @@ package cfg
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/ava-labs/avash/utils/logging"
@@ -17,25 +18,34 @@ import (
 
 // Configuration is a shell-usable wrapper of the config file
 type Configuration struct {
-	AvaLocation, DataDir	string
-	Log						logging.Log
+	AvaLocation, DataDir string
+	Log                  logging.Log
 }
 
 type configFile struct {
-	AvaLocation, DataDir	string
-	Log						configFileLog
+	AvaLocation, DataDir string
+	Log                  configFileLog
 }
 
 type configFileLog struct {
-	Terminal, LogFile, Dir	string
+	Terminal, LogFile, Dir string
 }
 
 // Config is a global instance of the shell configuration
 var Config Configuration
 
+// defaultCfgName is the default config name
+const defaultCfgName = ".avash.yaml"
+
 // InitConfig initializes the config for commands to reference
 func InitConfig() {
-	cfgname := ".avash.yaml"
+	cfgname := defaultCfgName
+	// allow the user to set the path to the config file
+	cfgpath := viper.GetString("conf")
+	if cfgpath != "" {
+		cfgpath, cfgname = filepath.Split(cfgpath)
+		viper.AddConfigPath(cfgpath)
+	}
 	viper.SetConfigName(cfgname)
 	viper.SetConfigType("yaml")
 	viper.AddConfigPath("$HOME/")
@@ -45,8 +55,8 @@ func InitConfig() {
 		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
 			home, _ := homedir.Dir()
 			os.OpenFile(home+"/"+cfgname, os.O_RDONLY|os.O_CREATE, 0644)
-			viper.SetConfigFile(home + "/" + cfgname)
-			fmt.Println("SetConfig to: " + home + "/" + cfgname)
+			viper.SetConfigFile(home + "/" + defaultCfgName)
+			fmt.Println("SetConfig to: " + home + "/" + defaultCfgName)
 		}
 	}
 
@@ -86,9 +96,9 @@ func InitConfig() {
 	}
 
 	Config = Configuration{
-		AvaLocation:	config.AvaLocation,
-		DataDir:		config.DataDir,
-		Log:			*log,
+		AvaLocation: config.AvaLocation,
+		DataDir:     config.DataDir,
+		Log:         *log,
 	}
 	Config.Log.Info("Avash successfully configured.")
 }

--- a/main.go
+++ b/main.go
@@ -3,9 +3,18 @@ package main
 import (
 	"github.com/ava-labs/avash/cfg"
 	"github.com/ava-labs/avash/cmd"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
 )
 
+var confFlag string
+
 func main() {
+	// allow config file path to be set by user
+	pflag.String("conf", ".avash.yaml", "Config file path")
+	pflag.Parse()
+	viper.BindPFlags(pflag.CommandLine)
+
 	cfg.InitConfig()
 	cmd.RootCmd.AddCommand(cmd.AVAWalletCmd)
 	cmd.RootCmd.AddCommand(cmd.ExitCmd)


### PR DESCRIPTION
This is my first PR to AVA code. If you are anything like me, you may be keeping config files in a specific folder instead of just $HOME.

`avash` does currently only accept a config file in the home folder, current path or `/etc/avash`. This PR allows a user to set a config file path via a command line flag `--conf`.


People are often very opinionated about the usage of their binaries, and how command line parameters and flags should be handled. This PR may very well not meet the maintainer's requirements, design principles and style. It is meant as first PR to "get my feet wet" with AVA, and because I personally would like to see this feature.

Tests should be added. However, proper testing of this would require running the actual binary, which is again a larger issue which should be discussed with the team. Happy to contribute to this end if deemed appropriate.