### PR TITLE
BUGFIX: Use contructor to create Keychain.

### DIFF
--- a/wallets/dags/wallet.go
+++ b/wallets/dags/wallet.go
@@ -27,7 +27,7 @@ func NewWallet(networkID uint32, subnetID ids.ID, txFee uint64) *Wallet {
 	return &Wallet{
 		networkID: networkID,
 		subnetID:  subnetID,
-		keyChain:  &spdagvm.Keychain{},
+		keyChain:  spdagvm.NewKeychain(networkID, subnetID),
 		utxoSet:   &UtxoSet{},
 		txFee:     txFee,
 	}


### PR DESCRIPTION
Trying to use an uninstantiated Keychain causes panics when trying to create new keys.

Bug repro steps:

```
avash> avawallet create mywallet 12345 i8KtK2KwLi1o7WaVBbEKpRLPtAEYayfoptqAFYxfQgrus1g6m 0
wallet created: mywallet
avash> avawallet addkey mywallet ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUrTXtNN
panic: assignment to entry in nil map

goroutine 1 [running]:
github.com/ava-labs/gecko/vms/spdagvm.(*Keychain).Add(0xc0000c04e0, 0xc000172ff0)
        /Users/tyler/dev/go/src/github.com/ava-labs/gecko/vms/spdagvm/keychain.go:55 +0x139
github.com/ava-labs/avash/wallets/dags.(*Wallet).ImportKey(...)
        /Users/tyler/dev/go/src/github.com/ava-labs/avash/wallets/dags/wallet.go:54
github.com/ava-labs/avash/cmd.glob..func4(0x4cb4720, 0xc0002df5c0, 0x2, 0x2)
        /Users/tyler/dev/go/src/github.com/ava-labs/avash/cmd/avawallet.go:100 +0x173
github.com/ava-labs/avash/cmd.(*Shell).ShellLoop(0xc000172d20)
        /Users/tyler/dev/go/src/github.com/ava-labs/avash/cmd/root.go:79 +0x416
github.com/ava-labs/avash/cmd.glob..func25(0x4cb2260, 0x4cdc920, 0x0, 0x0)
        /Users/tyler/dev/go/src/github.com/ava-labs/avash/cmd/root.go:111 +0x48
github.com/ava-labs/avash/cmd.(*Shell).ShellLoop(0xc000172d20)
        /Users/tyler/dev/go/src/github.com/ava-labs/avash/cmd/root.go:79 +0x416
github.com/ava-labs/avash/cmd.glob..func25(0x4cb2260, 0x4cdc920, 0x0, 0x0)
        /Users/tyler/dev/go/src/github.com/ava-labs/avash/cmd/root.go:111 +0x48
github.com/ava-labs/avash/cmd.(*Shell).ShellLoop(0xc000172d20)
        /Users/tyler/dev/go/src/github.com/ava-labs/avash/cmd/root.go:79 +0x416
github.com/ava-labs/avash/cmd.glob..func25(0x4cb2260, 0x4cdc920, 0x0, 0x0)
        /Users/tyler/dev/go/src/github.com/ava-labs/avash/cmd/root.go:111 +0x48
github.com/spf13/cobra.(*Command).execute(0x4cb2260, 0xc0000d4000, 0x0, 0x0, 0x4cb2260, 0xc0000d4000)
        /Users/tyler/dev/go/src/github.com/spf13/cobra/command.go:845 +0x2aa
github.com/spf13/cobra.(*Command).ExecuteC(0x4cb2260, 0x0, 0x0, 0x0)
        /Users/tyler/dev/go/src/github.com/spf13/cobra/command.go:946 +0x317
github.com/spf13/cobra.(*Command).Execute(...)
        /Users/tyler/dev/go/src/github.com/spf13/cobra/command.go:886
github.com/ava-labs/avash/cmd.Execute()
        /Users/tyler/dev/go/src/github.com/ava-labs/avash/cmd/root.go:118 +0x2d
main.main()
        /Users/tyler/dev/go/src/github.com/ava-labs/avash/main.go:8 +0x20
<avash>

```