### PR TITLE
Return from callrpc for nil store

### DIFF
--- a/cmd/callrpc.go
+++ b/cmd/callrpc.go
@@ -62,6 +62,7 @@ var CallRPCCmd = &cobra.Command{
 		store, err := AvashVars.Get(args[4])
 		if err != nil {
 			log.Error("store not found: %s", args[4])
+			return
 		}
 		store.Set(args[5], resVal)
 		log.Info("Response saved to %q.%q", args[4], args[5])


### PR DESCRIPTION
This will fix a panic for callrpc when the store hasn't been set yet.

```
github.com/ava-labs/avash/cmd.(*VarScope).Set(...)
	/go/src/github.com/ava-labs/avash/cmd/varstore.go:44
github.com/ava-labs/avash/cmd.glob..func14(0x4d67780, 0xc0002921e0, 0x6, 0x6)
	/go/src/github.com/ava-labs/avash/cmd/callrpc.go:67 +0x682
```