### PR TITLE
Roll back auth token support.

### DIFF
--- a/cmd/startnode.go
+++ b/cmd/startnode.go
@@ -146,7 +146,4 @@ func init() {
 	StartnodeCmd.Flags().UintVar(&flags.StakingPort, "staking-port", flags.StakingPort, "Port of the consensus server.")
 	StartnodeCmd.Flags().StringVar(&flags.StakingTLSCertFile, "staking-tls-cert-file", flags.StakingTLSCertFile, "TLS certificate file for staking connections. Relative to the avash binary if doesn't start with '/'. Ex: certs/keys1/staker.crt")
 	StartnodeCmd.Flags().StringVar(&flags.StakingTLSKeyFile, "staking-tls-key-file", flags.StakingTLSKeyFile, "TLS private key file for staking connections. Relative to the avash binary if doesn't start with '/'. Ex: certs/keys1/staker.key")
-
-	StartnodeCmd.Flags().BoolVar(&flags.APIRequireAuth, "api-require-auth", flags.APIRequireAuth, "If the node is started with this CLI, all API calls require authorization tokens.")
-	StartnodeCmd.Flags().StringVar(&flags.APIAuthPassword, "api-auth-password", flags.APIAuthPassword, "If you run your node with `--api-require-auth`, you must also specify an authorization token password with this CLI")
 }

--- a/node/cli_tools.go
+++ b/node/cli_tools.go
@@ -80,8 +80,6 @@ func FlagsToArgs(flags Flags, basedir string, sepBase bool) ([]string, Metadata)
 		"--staking-port=" + stakingPortString,
 		"--staking-tls-key-file=" + stakerKeyFile,
 		"--staking-tls-cert-file=" + stakerCertFile,
-		"--api-require-auth=" + strconv.FormatBool(flags.APIRequireAuth),
-		"--api-auth-password=" + flags.APIAuthPassword,
 	}
 	if sepBase {
 		args = append(args, "--data-dir="+basedir)

--- a/node/config.go
+++ b/node/config.go
@@ -71,10 +71,6 @@ type Flags struct {
 	StakingPort        uint
 	StakingTLSKeyFile  string
 	StakingTLSCertFile string
-
-	// Auth
-	APIRequireAuth  bool
-	APIAuthPassword string
 }
 
 // FlagsYAML mimics Flags but uses pointers for proper YAML interpretation

--- a/node/config.go
+++ b/node/config.go
@@ -115,8 +115,6 @@ type FlagsYAML struct {
 	StakingPort                  *uint   `yaml:"staking-port,omitempty"`
 	StakingTLSKeyFile            *string `yaml:"staking-tls-key-file,omitempty"`
 	StakingTLSCertFile           *string `yaml:"staking-tls-cert-file,omitempty"`
-	APIRequireAuth               *bool   `yaml:"api-require-auth,omitempty"`
-	APIAuthPassword              *string `yaml:"api-auth-password,omitempty"`
 }
 
 // SetDefaults sets any zero-value field to its default value
@@ -185,7 +183,5 @@ func DefaultFlags() Flags {
 		StakingPort:                  9651,
 		StakingTLSKeyFile:            "",
 		StakingTLSCertFile:           "",
-		APIRequireAuth:               false,
-		APIAuthPassword:              "",
 	}
 }


### PR DESCRIPTION
Rolling back auth token support until it lands in Gecko.