### PR TITLE
Add `api-health-enabled` flag.

### DIFF
--- a/cmd/startnode.go
+++ b/cmd/startnode.go
@@ -113,6 +113,7 @@ func init() {
 	StartnodeCmd.Flags().BoolVar(&flags.APIKeystoreEnabled, "api-keystore-enabled", flags.APIKeystoreEnabled, "If true, this node exposes the Keystore API")
 	StartnodeCmd.Flags().BoolVar(&flags.APIMetricsEnabled, "api-metrics-enabled", flags.APIMetricsEnabled, "If true, this node exposes the Metrics API")
 	StartnodeCmd.Flags().BoolVar(&flags.APIIPCsEnabled, "api-ipcs-enabled", flags.APIIPCsEnabled, "If true, IPCs can be opened")
+	StartnodeCmd.Flags().BoolVar(&flags.APIHealthEnabled, "api-health-enabled", flags.APIHealthEnabled, "If set to `true`, this node will expose the Health API. Defaults to `true`")
 
 	StartnodeCmd.Flags().StringVar(&flags.PublicIP, "public-ip", flags.PublicIP, "Public IP of this node.")
 	StartnodeCmd.Flags().StringVar(&flags.NetworkID, "network-id", flags.NetworkID, "Network ID this node will connect to.")
@@ -152,6 +153,4 @@ func init() {
 	StartnodeCmd.Flags().StringVar(&flags.MinStakeDuration, "min-stake-duration", flags.MinStakeDuration, "Set the minimum staking duration. Ex: --min-stake-duration=5m")
 
 	StartnodeCmd.Flags().StringVar(&flags.WhitelistedSubnets, "whitelisted-subnets", flags.WhitelistedSubnets, "Comma separated list of subnets that this node would validate if added to. Defaults to empty (will only validate the Primary Network)")
-
-	StartnodeCmd.Flags().BoolVar(&flags.APIHealthEnabled, "api-health-enabled", flags.APIHealthEnabled, "If set to `true`, this node will expose the Health API. Defaults to `true`")
 }

--- a/cmd/startnode.go
+++ b/cmd/startnode.go
@@ -152,4 +152,6 @@ func init() {
 	StartnodeCmd.Flags().StringVar(&flags.MinStakeDuration, "min-stake-duration", flags.MinStakeDuration, "Set the minimum staking duration. Ex: --min-stake-duration=5m")
 
 	StartnodeCmd.Flags().StringVar(&flags.WhitelistedSubnets, "whitelisted-subnets", flags.WhitelistedSubnets, "Comma separated list of subnets that this node would validate if added to. Defaults to empty (will only validate the Primary Network)")
+
+	StartnodeCmd.Flags().BoolVar(&flags.APIHealthEnabled, "api-health-enabled", flags.APIHealthEnabled, "If set to `true`, this node will expose the Health API. Defaults to `true`")
 }

--- a/network/startnode.sh
+++ b/network/startnode.sh
@@ -53,6 +53,7 @@ do
 		--api-auth-password=*|\
         --min-stake-duration=*|\
         --whitelisted-subnets=*|\
+        --api-health-enabled=*|\
         --db-dir=*|\
         --log-dir=*|\
         --plugin-dir=*)

--- a/node/cli_tools.go
+++ b/node/cli_tools.go
@@ -84,7 +84,7 @@ func FlagsToArgs(flags Flags, basedir string, sepBase bool) ([]string, Metadata)
 		"--api-auth-password=" + flags.APIAuthPassword,
 		"--min-stake-duration=" + flags.MinStakeDuration,
 		"--whitelisted-subnets=" + flags.WhitelistedSubnets,
-		"--api-health-enabled=" + flags.APIHealthEnabled,
+		"--api-health-enabled=" + strconv.FormatBool(flags.APIHealthEnabled),
 	}
 	if sepBase {
 		args = append(args, "--data-dir="+basedir)

--- a/node/cli_tools.go
+++ b/node/cli_tools.go
@@ -84,6 +84,7 @@ func FlagsToArgs(flags Flags, basedir string, sepBase bool) ([]string, Metadata)
 		"--api-auth-password=" + flags.APIAuthPassword,
 		"--min-stake-duration=" + flags.MinStakeDuration,
 		"--whitelisted-subnets=" + flags.WhitelistedSubnets,
+		"--api-health-enabled=" + flags.APIHealthEnabled,
 	}
 	if sepBase {
 		args = append(args, "--data-dir="+basedir)

--- a/node/config.go
+++ b/node/config.go
@@ -38,6 +38,7 @@ type Flags struct {
 	APIIPCsEnabled     bool
 	APIKeystoreEnabled bool
 	APIMetricsEnabled  bool
+	APIHealthEnabled   bool
 
 	// HTTP
 	HTTPPort        uint
@@ -81,9 +82,6 @@ type Flags struct {
 
 	// Whitelisted Subnets
 	WhitelistedSubnets string
-
-	// Health nabled
-	APIHealthEnabled bool
 }
 
 // FlagsYAML mimics Flags but uses pointers for proper YAML interpretation
@@ -128,7 +126,7 @@ type FlagsYAML struct {
 	APIAuthPassword              *string `yaml:"api-auth-password,omitempty"`
 	MinStakeDuration             *string `yaml:"min-stake-duration,omitempty"`
 	WhitelistedSubnets           *string `yaml:"whitelisted-subnets,omitempty"`
-	APIHealthEnabled             *string `yaml:"api-health-enabled,omitempty"`
+	APIHealthEnabled             *bool   `yaml:"api-health-enabled,omitempty"`
 }
 
 // SetDefaults sets any zero-value field to its default value

--- a/node/config.go
+++ b/node/config.go
@@ -81,6 +81,9 @@ type Flags struct {
 
 	// Whitelisted Subnets
 	WhitelistedSubnets string
+
+	// Health nabled
+	APIHealthEnabled bool
 }
 
 // FlagsYAML mimics Flags but uses pointers for proper YAML interpretation
@@ -125,6 +128,7 @@ type FlagsYAML struct {
 	APIAuthPassword              *string `yaml:"api-auth-password,omitempty"`
 	MinStakeDuration             *string `yaml:"min-stake-duration,omitempty"`
 	WhitelistedSubnets           *string `yaml:"whitelisted-subnets,omitempty"`
+	APIHealthEnabled             *string `yaml:"api-health-enabled,omitempty"`
 }
 
 // SetDefaults sets any zero-value field to its default value

--- a/node/config.go
+++ b/node/config.go
@@ -200,5 +200,6 @@ func DefaultFlags() Flags {
 		APIAuthRequired:              false,
 		APIAuthPassword:              "",
 		MinStakeDuration:             "",
+		APIHealthEnabled:             true,
 	}
 }


### PR DESCRIPTION
When I add `--api-health-enabled=false` to `scripts/five_node_staking.lua` avash fails to start and I get this error

```zsh
Recovered panic from runtime error: invalid memory address or nil pointer dereference
```
This PR matches [the PR](https://github.com/ava-labs/avash/pull/69) to add support for `--api-info-enabled` and that PR works properly.

Why does this PR fail but the other PR, which is nearly identical, work properly? Is there something internal which is calling the Health RPC which causes this runtime error when the Health RPC is disabled?