### PR TITLE
Add support for the `api-info-enabled` flag.

### DIFF
--- a/cmd/startnode.go
+++ b/cmd/startnode.go
@@ -113,6 +113,7 @@ func init() {
 	StartnodeCmd.Flags().BoolVar(&flags.APIKeystoreEnabled, "api-keystore-enabled", flags.APIKeystoreEnabled, "If true, this node exposes the Keystore API")
 	StartnodeCmd.Flags().BoolVar(&flags.APIMetricsEnabled, "api-metrics-enabled", flags.APIMetricsEnabled, "If true, this node exposes the Metrics API")
 	StartnodeCmd.Flags().BoolVar(&flags.APIIPCsEnabled, "api-ipcs-enabled", flags.APIIPCsEnabled, "If true, IPCs can be opened")
+	StartnodeCmd.Flags().BoolVar(&flags.APIInfoEnabled, "api-info-enabled", flags.APIInfoEnabled, "If set to `true`, this node will expose the Info API. Defaults to `true`")
 
 	StartnodeCmd.Flags().StringVar(&flags.PublicIP, "public-ip", flags.PublicIP, "Public IP of this node.")
 	StartnodeCmd.Flags().StringVar(&flags.NetworkID, "network-id", flags.NetworkID, "Network ID this node will connect to.")

--- a/network/startnode.sh
+++ b/network/startnode.sh
@@ -53,6 +53,7 @@ do
 		--api-auth-password=*|\
         --min-stake-duration=*|\
         --whitelisted-subnets=*|\
+        --api-info-enabled=*|\
         --db-dir=*|\
         --log-dir=*|\
         --plugin-dir=*)

--- a/node/cli_tools.go
+++ b/node/cli_tools.go
@@ -84,7 +84,7 @@ func FlagsToArgs(flags Flags, basedir string, sepBase bool) ([]string, Metadata)
 		"--api-auth-password=" + flags.APIAuthPassword,
 		"--min-stake-duration=" + flags.MinStakeDuration,
 		"--whitelisted-subnets=" + flags.WhitelistedSubnets,
-		"--api-info-required=" + strconv.FormatBool(flags.APIInfoEnabled),
+		"--api-info-enabled=" + strconv.FormatBool(flags.APIInfoEnabled),
 	}
 	if sepBase {
 		args = append(args, "--data-dir="+basedir)

--- a/node/cli_tools.go
+++ b/node/cli_tools.go
@@ -84,7 +84,7 @@ func FlagsToArgs(flags Flags, basedir string, sepBase bool) ([]string, Metadata)
 		"--api-auth-password=" + flags.APIAuthPassword,
 		"--min-stake-duration=" + flags.MinStakeDuration,
 		"--whitelisted-subnets=" + flags.WhitelistedSubnets,
-		"--api-info-enabled=" + flags.APIInfoEnabled,
+		"--api-info-required=" + strconv.FormatBool(flags.APIInfoEnabled),
 	}
 	if sepBase {
 		args = append(args, "--data-dir="+basedir)

--- a/node/cli_tools.go
+++ b/node/cli_tools.go
@@ -84,6 +84,7 @@ func FlagsToArgs(flags Flags, basedir string, sepBase bool) ([]string, Metadata)
 		"--api-auth-password=" + flags.APIAuthPassword,
 		"--min-stake-duration=" + flags.MinStakeDuration,
 		"--whitelisted-subnets=" + flags.WhitelistedSubnets,
+		"--api-info-enabled=" + flags.APIInfoEnabled,
 	}
 	if sepBase {
 		args = append(args, "--data-dir="+basedir)

--- a/node/config.go
+++ b/node/config.go
@@ -38,6 +38,7 @@ type Flags struct {
 	APIIPCsEnabled     bool
 	APIKeystoreEnabled bool
 	APIMetricsEnabled  bool
+	APIInfoEnabled     bool
 
 	// HTTP
 	HTTPPort        uint
@@ -125,6 +126,7 @@ type FlagsYAML struct {
 	APIAuthPassword              *string `yaml:"api-auth-password,omitempty"`
 	MinStakeDuration             *string `yaml:"min-stake-duration,omitempty"`
 	WhitelistedSubnets           *string `yaml:"whitelisted-subnets,omitempty"`
+	APIInfoEnabled               *bool   `yaml:"api-info-enabled,omitempty"`
 }
 
 // SetDefaults sets any zero-value field to its default value
@@ -196,5 +198,6 @@ func DefaultFlags() Flags {
 		APIAuthRequired:              false,
 		APIAuthPassword:              "",
 		MinStakeDuration:             "",
+		APIInfoEnabled:               true,
 	}
 }


### PR DESCRIPTION
## --api-info-enabled=false

To test add `--api-info-enabled=false` to [scripts/five_node_staking.lua](https://github.com/ava-labs/avash/blob/master/scripts/five_node_staking.lua). You will then get a 404 for any `info` RPC calls.

Example:

```zsh
curl --location --request POST 'http://localhost:9650/ext/info' \
--header 'Content-Type: application/json' \
--data-raw '{
    "jsonrpc":"2.0",
    "id"     :1,
    "method" :"info.peers",
    "params" :{
    }
}'

404 page not found
```

## --api-info-enabled=true or not adding it

Setting `--api-info-enabled=true` or not adding it at all will correctly work since that flag defaults to `true`

Example:

```zsh
curl --location --request POST 'http://localhost:9650/ext/info' \
--header 'Content-Type: application/json' \
--data-raw '{
    "jsonrpc":"2.0",
    "id"     :1,
    "method" :"info.peers",
    "params" :{
    }
}'

{
    "jsonrpc": "2.0",
    "result": {
        "numPeers": "4",
        "peers": [
            {
                "ip": "127.0.0.1:58679",
                "publicIP": "127.0.0.1:9659",
                "nodeID": "NodeID-P7oB2McjBGgW2NXXWVYjV8JEDFoW9xDE5",
                "version": "avalanche/1.1.0",
                "lastSent": "2020-12-09T16:19:58-08:00",
                "lastReceived": "2020-12-09T16:19:58-08:00"
            },
            {
                "ip": "127.0.0.1:58676",
                "publicIP": "127.0.0.1:9653",
                "nodeID": "NodeID-MFrZFVCXPv5iCn6M9K6XduxGTYp891xXZ",
                "version": "avalanche/1.1.0",
                "lastSent": "2020-12-09T16:19:58-08:00",
                "lastReceived": "2020-12-09T16:19:58-08:00"
            },
            {
                "ip": "127.0.0.1:58675",
                "publicIP": "127.0.0.1:9657",
                "nodeID": "NodeID-GWPcbFJZFfZreETSoWjPimr846mXEKCtu",
                "version": "avalanche/1.1.0",
                "lastSent": "2020-12-09T16:19:58-08:00",
                "lastReceived": "2020-12-09T16:19:58-08:00"
            },
            {
                "ip": "127.0.0.1:58674",
                "publicIP": "127.0.0.1:9655",
                "nodeID": "NodeID-NFBbbJ4qCmNaCzeW7sxErhvWqvEQMnYcN",
                "version": "avalanche/1.1.0",
                "lastSent": "2020-12-09T16:19:58-08:00",
                "lastReceived": "2020-12-09T16:19:58-08:00"
            }
        ]
    },
    "id": 1
}
```