### PR TITLE
Add --http-host flag.

### DIFF
--- a/cmd/startnode.go
+++ b/cmd/startnode.go
@@ -121,6 +121,7 @@ func init() {
 	StartnodeCmd.Flags().BoolVar(&flags.XputServerEnabled, "xput-server-enabled", flags.XputServerEnabled, "If true, throughput test server is created.")
 	StartnodeCmd.Flags().BoolVar(&flags.SignatureVerificationEnabled, "signature-verification-enabled", flags.SignatureVerificationEnabled, "Turn on signature verification.")
 
+	StartnodeCmd.Flags().StringVar(&flags.HTTPHost, "http-host", flags.HTTPHost, "The address that HTTP APIs listen on.")
 	StartnodeCmd.Flags().UintVar(&flags.HTTPPort, "http-port", flags.HTTPPort, "Port of the HTTP server.")
 	StartnodeCmd.Flags().BoolVar(&flags.HTTPTLSEnabled, "http-tls-enabled", flags.HTTPTLSEnabled, "Upgrade the HTTP server to HTTPS.")
 	StartnodeCmd.Flags().StringVar(&flags.HTTPTLSCertFile, "http-tls-cert-file", flags.HTTPTLSCertFile, "TLS certificate file for the HTTPS server.")

--- a/network/startnode.sh
+++ b/network/startnode.sh
@@ -55,6 +55,7 @@ do
         --whitelisted-subnets=*|\
         --config-file=*|\
         --api-info-enabled=*|\
+        --http-host=*|\
         --db-dir=*|\
         --log-dir=*|\
         --plugin-dir=*)

--- a/node/cli_tools.go
+++ b/node/cli_tools.go
@@ -58,6 +58,7 @@ func FlagsToArgs(flags Flags, basedir string, sepBase bool) ([]string, Metadata)
 		"--api-ipcs-enabled=" + strconv.FormatBool(flags.APIIPCsEnabled),
 		"--api-keystore-enabled=" + strconv.FormatBool(flags.APIKeystoreEnabled),
 		"--api-metrics-enabled=" + strconv.FormatBool(flags.APIMetricsEnabled),
+		"--http-host=" + flags.HTTPHost,
 		"--http-port=" + httpPortString,
 		"--http-tls-enabled=" + strconv.FormatBool(flags.HTTPTLSEnabled),
 		"--http-tls-cert-file=" + httpCertFile,

--- a/node/config.go
+++ b/node/config.go
@@ -41,6 +41,7 @@ type Flags struct {
 	APIInfoEnabled     bool
 
 	// HTTP
+	HTTPHost        string
 	HTTPPort        uint
 	HTTPTLSEnabled  bool
 	HTTPTLSCertFile string
@@ -104,6 +105,7 @@ type FlagsYAML struct {
 	APIIPCsEnabled               *bool   `yaml:"api-ipcs-enabled,omitempty"`
 	APIKeystoreEnabled           *bool   `yaml:"api-keystore-enabled,omitempty"`
 	APIMetricsEnabled            *bool   `yaml:"api-metrics-enabled,omitempty"`
+	HTTPHost                     *string `yaml:"http-host,omitempty"`
 	HTTPPort                     *uint   `yaml:"http-port,omitempty"`
 	HTTPTLSEnabled               *bool   `yaml:"http-tls-enabled,omitempty"`
 	HTTPTLSCertFile              *string `yaml:"http-tls-cert-file,omitempty"`
@@ -177,6 +179,7 @@ func DefaultFlags() Flags {
 		APIIPCsEnabled:               true,
 		APIKeystoreEnabled:           true,
 		APIMetricsEnabled:            true,
+		HTTPHost:                     "127.0.0.1",
 		HTTPPort:                     9650,
 		HTTPTLSEnabled:               false,
 		HTTPTLSCertFile:              "",


### PR DESCRIPTION
`--http-host=` works but others fail.

```zsh
--http-host=1.2.3.4
FATAL[12-10|14:45:24] node/node.go#334: API server dispatch failed with listen tcp 1.2.3.4:9650: bind: can't assign requested address

--http-host=127.0.0.2
FATAL[12-10|14:41:50] node/node.go#334: API server dispatch failed with listen tcp 127.0.0.2:9650: bind: can't assign requested address
```