### PR TITLE
`--fd-limit` flag.

### DIFF
--- a/cmd/startnode.go
+++ b/cmd/startnode.go
@@ -155,4 +155,6 @@ func init() {
 	StartnodeCmd.Flags().StringVar(&flags.WhitelistedSubnets, "whitelisted-subnets", flags.WhitelistedSubnets, "Comma separated list of subnets that this node would validate if added to. Defaults to empty (will only validate the Primary Network)")
 
 	StartnodeCmd.Flags().StringVar(&flags.ConfigFile, "config-file", flags.ConfigFile, "Config file specifies a JSON file to configure a node instead of specifying arguments via the command line. Command line arguments will override any options set in the config file.")
+
+	StartnodeCmd.Flags().IntVar(&flags.FDLimit, "fd-limit", flags.FDLimit, "Attempts to raise the process file descriptor limit to at least this value. Defaults to `32768`")
 }

--- a/network/startnode.sh
+++ b/network/startnode.sh
@@ -55,6 +55,7 @@ do
         --whitelisted-subnets=*|\
         --config-file=*|\
         --api-info-enabled=*|\
+        --fd-limit=*|\
         --db-dir=*|\
         --log-dir=*|\
         --plugin-dir=*)

--- a/node/cli_tools.go
+++ b/node/cli_tools.go
@@ -86,6 +86,7 @@ func FlagsToArgs(flags Flags, basedir string, sepBase bool) ([]string, Metadata)
 		"--whitelisted-subnets=" + flags.WhitelistedSubnets,
 		"--config-file=" + flags.ConfigFile,
 		"--api-info-enabled=" + strconv.FormatBool(flags.APIInfoEnabled),
+		"--fd-limit=" + strconv.Itoa(flags.FDLimit),
 	}
 	if sepBase {
 		args = append(args, "--data-dir="+basedir)

--- a/node/config.go
+++ b/node/config.go
@@ -85,6 +85,9 @@ type Flags struct {
 
 	// Config
 	ConfigFile string
+
+	// File Descriptor Limit
+	FDLimit int
 }
 
 // FlagsYAML mimics Flags but uses pointers for proper YAML interpretation
@@ -131,6 +134,7 @@ type FlagsYAML struct {
 	WhitelistedSubnets           *string `yaml:"whitelisted-subnets,omitempty"`
 	ConfigFile                   *string `yaml:"config-file,omitempty"`
 	APIInfoEnabled               *bool   `yaml:"api-info-enabled,omitempty"`
+	FDLimit                      *int    `yaml:"fd-limit,omitempty"`
 }
 
 // SetDefaults sets any zero-value field to its default value
@@ -205,5 +209,6 @@ func DefaultFlags() Flags {
 		ConfigFile:                   "",
 		WhitelistedSubnets:           "",
 		APIInfoEnabled:               true,
+		FDLimit:                      32768,
 	}
 }


### PR DESCRIPTION
Example:

```zsh
 --fd-limit=12768
```

Defaults to

```zsh
--fd-limit=32768
```