### PR TITLE
`log-display-level` flag.

### DIFF
--- a/cmd/startnode.go
+++ b/cmd/startnode.go
@@ -134,6 +134,7 @@ func init() {
 
 	StartnodeCmd.Flags().StringVar(&flags.LogLevel, "log-level", flags.LogLevel, "Specify the log level. Should be one of {verbo, debug, info, warn, error, fatal, off}")
 	StartnodeCmd.Flags().StringVar(&flags.LogDir, "log-dir", flags.LogDir, "Name of directory for the node's logging.")
+	StartnodeCmd.Flags().StringVar(&flags.LogDisplayLevel, "log-display-level", flags.LogDisplayLevel, "{Off, Fatal, Error, Warn, Info, Debug, Verbo}. The log level determines which events to display to the screen. If left blank, will default to the value provided to `--log-level`")
 
 	StartnodeCmd.Flags().IntVar(&flags.SnowAvalancheBatchSize, "snow-avalanche-batch-size", flags.SnowAvalancheBatchSize, "Number of operations to batch in each new vertex.")
 	StartnodeCmd.Flags().IntVar(&flags.SnowAvalancheNumParents, "snow-avalanche-num-parents", flags.SnowAvalancheNumParents, "Number of vertexes for reference from each new vertex.")

--- a/network/startnode.sh
+++ b/network/startnode.sh
@@ -55,6 +55,7 @@ do
         --whitelisted-subnets=*|\
         --config-file=*|\
         --api-info-enabled=*|\
+        --log-display-level=*|\
         --db-dir=*|\
         --log-dir=*|\
         --plugin-dir=*)

--- a/node/cli_tools.go
+++ b/node/cli_tools.go
@@ -69,6 +69,7 @@ func FlagsToArgs(flags Flags, basedir string, sepBase bool) ([]string, Metadata)
 		"--plugin-dir=" + flags.PluginDir,
 		"--log-level=" + flags.LogLevel,
 		"--log-dir=" + logPath,
+		"--log-display-level=" + flags.LogDisplayLevel,
 		"--snow-avalanche-batch-size=" + strconv.Itoa(flags.SnowAvalancheBatchSize),
 		"--snow-avalanche-num-parents=" + strconv.Itoa(flags.SnowAvalancheNumParents),
 		"--snow-sample-size=" + strconv.Itoa(flags.SnowSampleSize),

--- a/node/config.go
+++ b/node/config.go
@@ -58,8 +58,9 @@ type Flags struct {
 	PluginDir string
 
 	// Logging
-	LogLevel string
-	LogDir   string
+	LogLevel        string
+	LogDir          string
+	LogDisplayLevel string
 
 	// Consensus
 	SnowAvalancheBatchSize      int
@@ -115,6 +116,7 @@ type FlagsYAML struct {
 	PluginDir                    *string `yaml:"plugin-dir,omitempty"`
 	LogLevel                     *string `yaml:"log-level,omitempty"`
 	LogDir                       *string `yaml:"log-dir,omitempty"`
+	LogDisplayLevel              *string `yaml:"log-display-level,omitempty"`
 	SnowAvalancheBatchSize       *int    `yaml:"snow-avalanche-batch-size,omitempty"`
 	SnowAvalancheNumParents      *int    `yaml:"snow-avalanche-num-parents,omitempty"`
 	SnowSampleSize               *int    `yaml:"snow-sample-size,omitempty"`
@@ -188,6 +190,7 @@ func DefaultFlags() Flags {
 		PluginDir:                    fmt.Sprintf("%s/src/github.com/ava-labs/avalanchego/build/plugins", os.Getenv("GOPATH")),
 		LogLevel:                     "info",
 		LogDir:                       "logs",
+		LogDisplayLevel:              "", // defaults to the value provided to --log-level
 		SnowAvalancheBatchSize:       30,
 		SnowAvalancheNumParents:      5,
 		SnowSampleSize:               2,


### PR DESCRIPTION
`{Off, Fatal, Error, Warn, Info, Debug, Verbo}`. The log level determines which events to display to the screen. If left blank, will default to the value provided to `--log-level`

Example

```zsh
 --log-display-level=Verbo
```