### PR TITLE
fix: Rename the key from `avalocation` to `avalancheLocation`

### DIFF
--- a/example.avash.yaml
+++ b/example.avash.yaml
@@ -1,4 +1,4 @@
-avalocation: <$GOPATH>/src/github.com/ava-labs/avalanchego/build/avalanchego
+avalancheLocation: <$GOPATH>/src/github.com/ava-labs/avalanchego/build/avalanchego
 datadir: <$GOPATH>/src/github.com/ava-labs/avash/stash
 log:
   terminal: info


### PR DESCRIPTION
Noticed that the example is using an outdated property (see here for the correct name : https://github.com/ava-labs/avash/blob/9f813fb5d8acf3c3dc528dd00dd25b9852a0afa1/cfg/cfg.go#L28)