### PR TITLE
Remove the NetworkTimeoutReduction flag as it was removed from Avalan…

### DIFF
--- a/cmd/startnode.go
+++ b/cmd/startnode.go
@@ -189,7 +189,6 @@ func init() {
 
 	StartnodeCmd.Flags().IntVar(&flags.MaxNonStakerPendingMsgs, "max-non-staker-pending-msgs", flags.MaxNonStakerPendingMsgs, "Maximum number of messages a non-staker is allowed to have pending. Defaults to `20`")
 
-	StartnodeCmd.Flags().StringVar(&flags.NetworkTimeoutReduction, "network-timeout-reduction", flags.NetworkTimeoutReduction, "Reduction duration of the timeout after a successful request. Defaults to `12ms`")
 	StartnodeCmd.Flags().StringVar(&flags.NetworkInitialTimeout, "network-initial-timeout", flags.NetworkInitialTimeout, "Initial timeout value of the adaptive timeout manager, in nanoseconds. Defaults to `5s`")
 	StartnodeCmd.Flags().StringVar(&flags.NetworkMinimumTimeout, "network-minimum-timeout", flags.NetworkMinimumTimeout, "Minimum timeout value of the adaptive timeout manager, in nanoseconds. Defaults to `5s`")
 	StartnodeCmd.Flags().StringVar(&flags.NetworkMaximumTimeout, "network-maximum-timeout", flags.NetworkMaximumTimeout, "Maximum timeout value of the adaptive timeout manager, in nanoseconds. Defaults to `10s`")

--- a/network/startnode.sh
+++ b/network/startnode.sh
@@ -52,7 +52,6 @@ do
 		--snow-virtuous-commit-threshold=*|\
 		--snow-rogue-commit-threshold=*|\
         --uptime-requirement=*|\
-		--network-timeout-reduction=*|\
 		--min-delegator-stake=*|\
 		--consensus-shutdown-timeout=*|\
 		--min-delegation-fee=*|\

--- a/node/cli_tools.go
+++ b/node/cli_tools.go
@@ -81,7 +81,6 @@ func FlagsToArgs(flags Flags, basedir string, sepBase bool) ([]string, Metadata)
 		"--snow-quorum-size=" + strconv.Itoa(flags.SnowQuorumSize),
 		"--snow-virtuous-commit-threshold=" + strconv.Itoa(flags.SnowVirtuousCommitThreshold),
 		"--snow-rogue-commit-threshold=" + strconv.Itoa(flags.SnowRogueCommitThreshold),
-		"--network-timeout-reduction=" + flags.NetworkTimeoutReduction,
 		"--min-delegator-stake=" + strconv.Itoa(flags.MinDelegatorStake),
 		"--consensus-shutdown-timeout=" + flags.ConsensusShutdownTimeout,
 		"--consensus-gossip-frequency=" + flags.ConsensusGossipFrequency,

--- a/node/config.go
+++ b/node/config.go
@@ -182,7 +182,6 @@ type FlagsYAML struct {
 	SnowQuorumSize               *int     `yaml:"snow-quorum-size,omitempty"`
 	SnowVirtuousCommitThreshold  *int     `yaml:"snow-virtuous-commit-threshold,omitempty"`
 	SnowRogueCommitThreshold     *int     `yaml:"snow-rogue-commit-threshold,omitempty"`
-	NetworkTimeoutReduction      *string  `yaml:"network-timeout-reduction,omitempty"`
 	MinDelegatorStake            *int     `yaml:"min-delegator-stake,omitempty"`
 	ConsensusShutdownTimeout     *string  `yaml:"consensus-shutdown-timeout,omitempty"`
 	ConsensusGossipFrequency     *string  `yaml:"consensus-gossip-frequency,omitempty"`


### PR DESCRIPTION
Remove the `NetworkTimeoutReduction` flag as it was removed from AvalancheGo in v1.2.1.