### PR TITLE
Fixed dead link to Avash documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Avash provides the ability to run Lua scripts which can execute a sequence of sh
  3. `cd $GOPATH/src/github.com/ava-labs/avash`
  4. `go build`
 
-For full documentation of Avash configuration and commands, please see the official [Avalanche Documentation](https://docs.avax.network/v1.0/en/tools/avash/).
+For full documentation of Avash configuration and commands, please see the official [Avalanche Documentation](https://docs.avax.network/build/tools/avash).
 
 ## Using Avash
 


### PR DESCRIPTION
Link points to old website. Updated to new documentation URL