### PR TITLE
Adds new lua script with a config file.

### DIFF
--- a/scripts/config/staking_node_config.json
+++ b/scripts/config/staking_node_config.json
@@ -1,0 +1,17 @@
+{
+    "db-enabled": false,
+    "staking-enabled": true,
+    "log-level": "debug",
+    "coreth-config": {
+        "snowman-api-enabled": false,
+        "coreth-admin-api-enabled": false,
+        "net-api-enabled": true,
+        "rpc-gas-cap": 2500000000,
+        "rpc-tx-fee-cap": 100,
+        "eth-api-enabled": true,
+        "tx-pool-api-enabled": true,
+        "debug-api-enabled": true,
+        "web3-api-enabled": true,
+        "personal-api-enabled": true
+    }
+}

--- a/scripts/five_node_staking_with_config.lua
+++ b/scripts/five_node_staking_with_config.lua
@@ -1,0 +1,11 @@
+cmds = {
+    "startnode node1 config-file=./scripts/config/staking_node_config.json --http-port=9650 --staking-port=9651 --bootstrap-ips= --staking-tls-cert-file=certs/keys1/staker.crt --staking-tls-key-file=certs/keys1/staker.key",
+    "startnode node2 config-file=./scripts/config/staking_node_config.json --http-port=9652 --staking-port=9653 --bootstrap-ips=127.0.0.1:9651 --bootstrap-ids=NodeID-7Xhw2mDxuDS44j42TCB6U5579esbSt3Lg --staking-tls-cert-file=certs/keys2/staker.crt --staking-tls-key-file=certs/keys2/staker.key",
+    "startnode node3 config-file=./scripts/config/staking_node_config.json --http-port=9654 --staking-port=9655 --bootstrap-ips=127.0.0.1:9651 --bootstrap-ids=NodeID-7Xhw2mDxuDS44j42TCB6U5579esbSt3Lg --staking-tls-cert-file=certs/keys3/staker.crt --staking-tls-key-file=certs/keys3/staker.key",
+    "startnode node4 config-file=./scripts/config/staking_node_config.json --http-port=9656 --staking-port=9657 --bootstrap-ips=127.0.0.1:9651 --bootstrap-ids=NodeID-7Xhw2mDxuDS44j42TCB6U5579esbSt3Lg --staking-tls-cert-file=certs/keys4/staker.crt --staking-tls-key-file=certs/keys4/staker.key",
+    "startnode node5 config-file=./scripts/config/staking_node_config.json --http-port=9658 --staking-port=9659 --bootstrap-ips=127.0.0.1:9651 --bootstrap-ids=NodeID-7Xhw2mDxuDS44j42TCB6U5579esbSt3Lg --staking-tls-cert-file=certs/keys5/staker.crt --staking-tls-key-file=certs/keys5/staker.key",
+}
+
+for key, cmd in ipairs(cmds) do
+    avash_call(cmd)
+end


### PR DESCRIPTION
Currently, the tutorial for writing smart contracts with truffle on avalanche (https://docs.avax.network/build/tutorials/smart-contracts/using-truffle-with-the-avalanche-c-chain) is broken because the personal_ namespace on coreth is disabled by default since 1.3.2 or thereabouts.

This change is the first step to fix this issue. This new Lua script, namely scripts/config/staking_node_config.json loads a config file that enables personal namespace and thereby fixing the doc. Later on, after this is merged, the script referenced in the doc needs to be changed as well.