### PR TITLE
Add removeall command

### DIFF
--- a/cmd/procmanager.go
+++ b/cmd/procmanager.go
@@ -226,6 +226,24 @@ var PMRemoveCmd = &cobra.Command{
 	},
 }
 
+// PMRemoveAllCmd represents the list operation on the procmanager command
+var PMRemoveAllCmd = &cobra.Command{
+	Use:   "removeall [optional: delay in secs]",
+	Short: "Removes all processes.",
+	Long:  `Removes all processes. It will stop the process if it is running.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		log := cfg.Config.Log
+		delay := time.Duration(0)
+		if len(args) >= 1 {
+			if v, e := strconv.ParseInt(args[0], 10, 64); e == nil && v > 0 {
+				delay = time.Duration(v)
+				log.Info("all processes will be removed in %ds", int(delay))
+			}
+		}
+		delayRun(pmgr.ProcManager.RemoveAllProcesses, delay)
+	},
+}
+
 func delayRun(f func(), delay time.Duration) {
 	if delay == 0 {
 		f()
@@ -244,6 +262,7 @@ func init() {
 	ProcmanagerCmd.AddCommand(PMListCmd)
 	ProcmanagerCmd.AddCommand(PMMetadataCmd)
 	ProcmanagerCmd.AddCommand(PMRemoveCmd)
+	ProcmanagerCmd.AddCommand(PMRemoveAllCmd)
 	ProcmanagerCmd.AddCommand(PMStopCmd)
 	ProcmanagerCmd.AddCommand(PMStopAllCmd)
 	ProcmanagerCmd.AddCommand(PMStartAllCmd)

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.1
+	github.com/stretchr/testify v1.7.0
 	github.com/ybbus/jsonrpc v2.1.2+incompatible
 	github.com/yourbasic/radix v0.0.0-20180308122924-cbe1cc82e907
 	github.com/yuin/gopher-lua v0.0.0-20200816102855-ee81675732da

--- a/go.sum
+++ b/go.sum
@@ -387,6 +387,7 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=

--- a/processmgr/processmanager.go
+++ b/processmgr/processmanager.go
@@ -152,6 +152,21 @@ func (pm *ProcessManager) RemoveProcess(name string) error {
 	return nil
 }
 
+// RemoveAllProcesses removes a process from the list of available named processes
+func (pm *ProcessManager) RemoveAllProcesses() {
+	pm.StopAllProcesses()
+	totalProcesses := len(pm.processes)
+	processesRemoved := 0
+	for name := range pm.processes {
+		if err := pm.RemoveProcess(name); err != nil {
+			cfg.Config.Log.Error(err.Error())
+			continue
+		}
+		processesRemoved++
+	}
+	cfg.Config.Log.Info("%d/%d processes removed", processesRemoved, totalProcesses)
+}
+
 // ProcessTable returns a formatted metadata table for the data provided
 func (pm *ProcessManager) ProcessTable(table *tablewriter.Table) *tablewriter.Table {
 	table.SetHeader([]string{"Name", "Status", "Metadata", "Command"})

--- a/processmgr/processmanager_test.go
+++ b/processmgr/processmanager_test.go
@@ -2,6 +2,7 @@ package processmgr
 
 import (
 	"fmt"
+	"github.com/stretchr/testify/assert"
 	"reflect"
 	"testing"
 )
@@ -10,7 +11,7 @@ func TestAddProcess(t *testing.T) {
 	pm := ProcessManager{
 		processes: make(map[string]*Process),
 	}
-	
+
 	cmd0 := "cmd0"
 	proctype0 := "type0"
 	args0 := []string{"arg0"}
@@ -151,6 +152,21 @@ func TestStartProcess(t *testing.T) {
 			t.Fatalf("PM.Processes does not contain %s", name0)
 		}
 	})
+}
+
+func TestRemoveAllProcesses(t *testing.T) {
+	pm := ProcessManager{
+		processes: make(map[string]*Process),
+	}
+
+	name := "procname-"
+	for i := 0; i < 5; i++ {
+		_ = pm.AddProcess("cmd", "fake-cmd", []string{"arg"}, name+string(rune(i)), "data", nil, nil, nil)
+	}
+
+	assert.Len(t, pm.processes, 5)
+	pm.RemoveAllProcesses()
+	assert.Len(t, pm.processes, 0)
 }
 
 func TestStopProcess(t *testing.T) {


### PR DESCRIPTION
Adds removeall command to procmanager so that all processes can be removed using a single command. 

Use-case: local debugging, when diagnosing issues that cause nodes to crash, they have to be removed individually before the next run can be started. Removeall simulates what is basically:

```
runscript scripts/...lua
#<few moments later, few nodes crash>
procmanager stopall
procmanager remove node1
procmanager remove node2
procmanager remove node3
procmanager remove node4
procmanager remove node5
runscript scripts/...lua
```

